### PR TITLE
Fixed the newline glitch

### DIFF
--- a/mutliadmin/MultiAdmin/OutputThread.cs
+++ b/mutliadmin/MultiAdmin/OutputThread.cs
@@ -130,8 +130,14 @@ namespace MultiAdmin
 							server.WritePart("", ConsoleColor.Cyan, 0, true, false);
 							server.WritePart("[" + match.Groups[1].Value + "] ", levelColour, 0, false, false);
 							server.WritePart(match.Groups[2].Value + " ", tagColour, 0, false, false);
-							server.WritePart(match.Groups[3].Value, msgColour, 0, false, true);
-							display = false;
+                            // OLD: server.WritePart(match.Groups[3].Value, msgColour, 0, false, true);
+                            // The regex.Match was trimming out the new lines and that is why no new lines were created.
+                            // To be sure this will not happen again:
+                            server.WritePart(gameMessage.Split(new char[] { ']' }, 3)[2], msgColour, 0, false, true);
+                            // This way, it outputs the whole message.
+                            // P.S. the format is [Info] [courtney.exampleplugin] Something intresting happened
+                            // That was just an example
+                            display = false;
 						}
 
 					}


### PR DESCRIPTION
The glitch where when the plugin outputed a newline anywhere, after the newline the program would no longer output after that newline.

The problem originates from the Regex.Match and it could be solved by setting it to Singeline mode but it then puts a newline at the end for no reason,so I decided to do it this way.

~Zero