### PR TITLE
Fixed another bug about newlines

### DIFF
--- a/mutliadmin/MultiAdmin/Server.cs
+++ b/mutliadmin/MultiAdmin/Server.cs
@@ -248,8 +248,16 @@ namespace MultiAdmin.MultiAdmin
 			Console.ForegroundColor = color;
 			if (lineEnd)
 			{
-				Console.Write(datepart + part + Environment.NewLine);
-				currentLine += datepart + part;
+                if (part.EndsWith(Environment.NewLine))
+                {
+                    //this.Write("This ends in a newline, not adding anymore!");
+                    Console.Write(datepart + part);
+                }
+                else
+                {
+                    Console.Write(datepart + part + Environment.NewLine);
+                }
+                currentLine += datepart + part;
 				Log(currentLine);
 				currentLine = "";
 			}

--- a/mutliadmin/MultiAdmin/Server.cs
+++ b/mutliadmin/MultiAdmin/Server.cs
@@ -10,7 +10,7 @@ namespace MultiAdmin.MultiAdmin
 {
 	public class Server
 	{
-		public static readonly string MA_VERSION = "1.4.3";
+		public static readonly string MA_VERSION = "1.4.5";
 
 		public Boolean HasServerMod { get; set; }
 		public String ServerModVersion { get; set; }


### PR DESCRIPTION
I have no idea why  but for some reason sometimes there are excesive newlines, and that is being added by WritePart.

The fact is since we aren't using the regex match for the last part, the newlines now get passed through. Due to because some lines do end with newline and others do not, I made a check to see if they end with a newline, just output w/o adding newline and if it is lacking one, add one!

This bug was put in evidence by the 1.4.4 bug fix

Note: For some reason I had to re-pull to notice this bug, the files were 100% the same and it worked fine last time. I guess computers can be weird.

Sorry for missing this bug out, as I said initially it was ok !