### PR TITLE
Version 3.1.1 Update

### DIFF
--- a/MultiAdmin/Config/MultiAdminConfig.cs
+++ b/MultiAdmin/Config/MultiAdminConfig.cs
@@ -89,9 +89,9 @@ namespace MultiAdmin.Config
 		#endregion
 
 		public const string ConfigFileName = "scp_multiadmin.cfg";
-		public static readonly string ConfigFilePath = Utils.GetFullPathSafe(ConfigFileName);
+		public static readonly string GlobalConfigFilePath = Utils.GetFullPathSafe(ConfigFileName);
 
-		public static readonly MultiAdminConfig GlobalConfig = new MultiAdminConfig(ConfigFilePath, null);
+		public static readonly MultiAdminConfig GlobalConfig = new MultiAdminConfig(GlobalConfigFilePath, null);
 
 		public MultiAdminConfig ParentConfig { get; }
 		public Config Config { get; }

--- a/MultiAdmin/Config/MultiAdminConfig.cs
+++ b/MultiAdmin/Config/MultiAdminConfig.cs
@@ -29,6 +29,9 @@ namespace MultiAdmin.Config
 		public const string DebugLogWhitelistKey = "multiadmin_debug_log_whitelist";
 		public string[] DebugLogWhitelist { get; private set; }
 
+		public const string UseNewInputSystemKey = "use_new_input_system";
+		public bool UseNewInputSystem { get; private set; }
+
 		public const string PortKey = "port";
 		public uint Port { get; private set; }
 
@@ -139,9 +142,10 @@ namespace MultiAdmin.Config
 			DisableConfigValidation = ShouldGetFromConfig(DisableConfigValidationKey) ? Config.GetBool(DisableConfigValidationKey, false) : ParentConfig.DisableConfigValidation;
 			ShareNonConfigs = ShouldGetFromConfig(ShareNonConfigsKey) ? Config.GetBool(ShareNonConfigsKey, true) : ParentConfig.ShareNonConfigs;
 			NoLog = ShouldGetFromConfig(NoLogKey) ? Config.GetBool(NoLogKey, false) : ParentConfig.NoLog;
-			DebugLog = ShouldGetFromConfig(DebugLogKey) ? Config.GetBool(DebugLogKey, false) : ParentConfig.DebugLog;
+			DebugLog = ShouldGetFromConfig(DebugLogKey) ? Config.GetBool(DebugLogKey, true) : ParentConfig.DebugLog;
 			DebugLogBlacklist = ShouldGetFromConfig(DebugLogBlacklistKey) ? Config.GetStringList(DebugLogBlacklistKey, new string[] {"ProcessFile"}) : ParentConfig.DebugLogBlacklist;
 			DebugLogWhitelist = ShouldGetFromConfig(DebugLogWhitelistKey) ? Config.GetStringList(DebugLogWhitelistKey, new string[0]) : ParentConfig.DebugLogWhitelist;
+			UseNewInputSystem = ShouldGetFromConfig(UseNewInputSystemKey) ? Config.GetBool(UseNewInputSystemKey, true) : ParentConfig.UseNewInputSystem;
 			Port = ShouldGetFromConfig(PortKey) ? Config.GetUInt(PortKey, 7777) : ParentConfig.Port;
 			CopyFromFolderOnReload = ShouldGetFromConfig(CopyFromFolderOnReloadKey) ? Config.GetString(CopyFromFolderOnReloadKey, "") : ParentConfig.CopyFromFolderOnReload;
 			FilesToCopyFromFolder = ShouldGetFromConfig(FilesToCopyFromFolderKey) ? Config.GetStringList(FilesToCopyFromFolderKey, new string[0]) : ParentConfig.FilesToCopyFromFolder;

--- a/MultiAdmin/ConsoleTools/ColoredConsole.cs
+++ b/MultiAdmin/ConsoleTools/ColoredConsole.cs
@@ -103,9 +103,7 @@ namespace MultiAdmin.ConsoleTools
 		{
 			lock (ColoredConsole.WriteLock)
 			{
-				if (clearConsoleLine)
-
-					ColoredConsole.Write(this);
+				ColoredConsole.Write(clearConsoleLine ? ConsoleUtils.ClearConsoleLine(this) : this);
 			}
 		}
 

--- a/MultiAdmin/ConsoleTools/ColoredConsole.cs
+++ b/MultiAdmin/ConsoleTools/ColoredConsole.cs
@@ -99,14 +99,22 @@ namespace MultiAdmin.ConsoleTools
 			return Clone();
 		}
 
-		public void Write()
+		public void Write(bool clearConsoleLine = false)
 		{
-			ColoredConsole.Write(this);
+			lock (ColoredConsole.WriteLock)
+			{
+				if (clearConsoleLine)
+
+					ColoredConsole.Write(this);
+			}
 		}
 
-		public void WriteLine()
+		public void WriteLine(bool clearConsoleLine = false)
 		{
-			ColoredConsole.WriteLine(this);
+			lock (ColoredConsole.WriteLock)
+			{
+				ColoredConsole.WriteLine(clearConsoleLine ? ConsoleUtils.ClearConsoleLine(this) : this);
+			}
 		}
 	}
 
@@ -130,19 +138,28 @@ namespace MultiAdmin.ConsoleTools
 			return JoinTextIgnoreNull(message);
 		}
 
-		public static void Write(this IEnumerable<ColoredMessage> message)
+		public static void Write(this IEnumerable<ColoredMessage> message, bool clearConsoleLine = false)
 		{
-			ColoredConsole.Write(message.ToArray());
+			lock (ColoredConsole.WriteLock)
+			{
+				ColoredConsole.Write(clearConsoleLine ? ConsoleUtils.ClearConsoleLine(message.ToArray()) : message.ToArray());
+			}
 		}
 
-		public static void WriteLine(this IEnumerable<ColoredMessage> message)
+		public static void WriteLine(this IEnumerable<ColoredMessage> message, bool clearConsoleLine = false)
 		{
-			ColoredConsole.WriteLine(message.ToArray());
+			lock (ColoredConsole.WriteLock)
+			{
+				ColoredConsole.WriteLine(clearConsoleLine ? ConsoleUtils.ClearConsoleLine(message.ToArray()) : message.ToArray());
+			}
 		}
 
-		public static void WriteLines(this IEnumerable<ColoredMessage> message)
+		public static void WriteLines(this IEnumerable<ColoredMessage> message, bool clearConsoleLine = false)
 		{
-			ColoredConsole.WriteLines(message.ToArray());
+			lock (ColoredConsole.WriteLock)
+			{
+				ColoredConsole.WriteLines(clearConsoleLine ? ConsoleUtils.ClearConsoleLine(message.ToArray()) : message.ToArray());
+			}
 		}
 	}
 }

--- a/MultiAdmin/ConsoleTools/ConsoleUtils.cs
+++ b/MultiAdmin/ConsoleTools/ConsoleUtils.cs
@@ -20,17 +20,24 @@ namespace MultiAdmin.ConsoleTools
 
 				try
 				{
-					int cursorReturnIndex = returnCursorPos ? Console.CursorLeft : 0;
+					int cursorLeftReturnIndex = returnCursorPos ? Console.CursorLeft : 0;
+					// Linux console uses visible section as a scrolling buffer,
+					// that means that making the console taller moves CursorTop to a higher index,
+					// but when the user makes the console smaller, CursorTop is left at a higher index than BufferHeight,
+					// causing an error
+					int cursorTopIndex = Math.Min(Console.CursorTop, Console.BufferHeight - 1);
 
-					Console.CursorLeft = IsIndexWithinBuffer(index) ? index : 0;
+					Console.SetCursorPosition(IsIndexWithinBuffer(index) ? index : 0, cursorTopIndex);
 
+					// If the message stretches to the end of the console window, the console window will generally wrap the line into a new line,
+					// so 1 is subtracted
 					int charCount = Console.BufferWidth - Console.CursorLeft - 1;
 					if (charCount > 0)
 					{
 						Console.Write(new string(' ', charCount));
 					}
 
-					Console.CursorLeft = cursorReturnIndex;
+					Console.SetCursorPosition(cursorLeftReturnIndex, cursorTopIndex);
 				}
 				catch (Exception e)
 				{

--- a/MultiAdmin/Features/MultiAdminInfo.cs
+++ b/MultiAdmin/Features/MultiAdminInfo.cs
@@ -50,13 +50,13 @@ namespace MultiAdmin.Features
 
 		public void PrintInfo()
 		{
-			Server.Write("MultiAdmin (https://github.com/Grover-c13/MultiAdmin/)", ConsoleColor.DarkMagenta);
+			Server.Write($"MultiAdmin v{Program.MaVersion} (https://github.com/Grover-c13/MultiAdmin/)", ConsoleColor.DarkMagenta);
 			Server.Write("Released under CC-BY-SA 4.0", ConsoleColor.DarkMagenta);
 		}
 
 		public override string GetFeatureDescription()
 		{
-			return "Prints MultiAdmin license information";
+			return "Prints MultiAdmin license and version information";
 		}
 
 		public override string GetFeatureName()

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -13,7 +13,7 @@ namespace MultiAdmin
 {
 	public static class Program
 	{
-		public const string MaVersion = "3.1.0";
+		public const string MaVersion = "3.1.1";
 
 		private static readonly List<Server> InstantiatedServers = new List<Server>();
 
@@ -59,7 +59,7 @@ namespace MultiAdmin
 			{
 				if (Headless) return;
 
-				ConsoleUtils.ClearConsoleLine(new ColoredMessage(Utils.TimeStampMessage(message), color)).WriteLine();
+				new ColoredMessage(Utils.TimeStampMessage(message), color).WriteLine(MultiAdminConfig.GlobalConfig.UseNewInputSystem);
 			}
 		}
 
@@ -74,21 +74,21 @@ namespace MultiAdmin
 			{
 				if (tag == null || !IsDebugLogTagAllowed(tag)) return;
 
-				LogDebug($"Error in \"{tag}\":{Environment.NewLine}{exception}");
+				LogDebug(tag, $"Error in \"{tag}\":{Environment.NewLine}{exception}");
 			}
 		}
 
-		public static void LogDebug(string message)
+		public static void LogDebug(string tag, string message)
 		{
 			lock (MaDebugLogFile)
 			{
-				if (!MultiAdminConfig.GlobalConfig.DebugLog || string.IsNullOrEmpty(MaDebugLogFile)) return;
+				if (!MultiAdminConfig.GlobalConfig.DebugLog || string.IsNullOrEmpty(MaDebugLogFile) || tag == null || !IsDebugLogTagAllowed(tag)) return;
 
 				Directory.CreateDirectory(MaDebugLogDir);
 
 				using (StreamWriter sw = File.AppendText(MaDebugLogFile))
 				{
-					message = Utils.TimeStampMessage(message);
+					message = Utils.TimeStampMessage($"[{tag}] {message}");
 					sw.Write(message);
 					if (!message.EndsWith(Environment.NewLine)) sw.WriteLine();
 				}

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -56,8 +56,6 @@ namespace MultiAdmin
 
 			// Register all features
 			RegisterFeatures();
-
-			ReloadConfig();
 		}
 
 		#region Server Status
@@ -222,6 +220,9 @@ namespace MultiAdmin
 
 				try
 				{
+					// Reload the config immediately as server is starting
+					ReloadConfig();
+
 					// Create session directory
 					PrepareSession();
 
@@ -543,8 +544,10 @@ namespace MultiAdmin
 
 				ColoredMessage[] timeStampedMessage = Utils.TimeStampMessage(messages, timeStampColor);
 
-				ConsoleUtils.ClearConsoleLine(timeStampedMessage).WriteLine();
-				InputThread.WriteInputAndSetCursor();
+				timeStampedMessage.WriteLine(ServerConfig.UseNewInputSystem);
+
+				if (ServerConfig.UseNewInputSystem)
+					InputThread.WriteInputAndSetCursor();
 			}
 		}
 
@@ -595,11 +598,6 @@ namespace MultiAdmin
 					if (!message.EndsWith(Environment.NewLine)) sw.WriteLine();
 				}
 			}
-		}
-
-		public void Log(ColoredMessage message)
-		{
-			Log(message?.text);
 		}
 
 		#endregion

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -220,6 +220,16 @@ namespace MultiAdmin
 
 				try
 				{
+					#region Startup Info Printing & Logging
+
+					if (!string.IsNullOrEmpty(MultiAdminConfig.GlobalConfigFilePath))
+						Write($"Using global config \"{MultiAdminConfig.GlobalConfigFilePath}\"...");
+
+					if (!string.IsNullOrEmpty(configLocation) && !string.IsNullOrEmpty(ServerConfig?.Config?.ConfigPath))
+						Write($"Using server config \"{ServerConfig.Config.ConfigPath}\"...");
+
+					#endregion
+
 					// Reload the config immediately as server is starting
 					ReloadConfig();
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ disable_config_validation | Boolean | False | Disable the config validator
 share_non_configs | Boolean | True | Makes all files other than the config files store in AppData
 multiadmin_nolog | Boolean | False | Disable logging to file
 multiadmin_debug_log | Boolean | True | Enables MultiAdmin debug logging, this logs to a separate file than any other logs
-multiadmin_debug_log_blacklist | String List | **Empty** | Which tags to block for MultiAdmin debug logging
+multiadmin_debug_log_blacklist | String List | ProcessFile | Which tags to block for MultiAdmin debug logging
 multiadmin_debug_log_whitelist | String List | **Empty** | Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)
 use_new_input_system | Boolean | True | Whether to use the new input system, if false, the original input system will be used
 port | Unsigned Integer | 7777 | The port for the server to use (Preparing for next game release, currently does nothing)

--- a/README.md
+++ b/README.md
@@ -91,4 +91,3 @@ start_config_on_full | String | **Empty** | Start server with this config folder
 
 ## Upcoming Features
 - Support for running multiple server instances in one MultiAdmin instance
-- Printing speed configuration option

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ config_location | String | **Empty** | The default location for the game to use 
 disable_config_validation | Boolean | False | Disable the config validator
 share_non_configs | Boolean | True | Makes all files other than the config files store in AppData
 multiadmin_nolog | Boolean | False | Disable logging to file
-multiadmin_debug_log | Boolean | False | Enables MultiAdmin debug logging, this logs to a separate file than any other logs
+multiadmin_debug_log | Boolean | True | Enables MultiAdmin debug logging, this logs to a separate file than any other logs
 multiadmin_debug_log_blacklist | String List | **Empty** | Which tags to block for MultiAdmin debug logging
 multiadmin_debug_log_whitelist | String List | **Empty** | Which tags to log for MultiAdmin debug logging (Defaults to logging all if none are provided)
+use_new_input_system | Boolean | True | Whether to use the new input system, if false, the original input system will be used
 port | Unsigned Integer | 7777 | The port for the server to use (Preparing for next game release, currently does nothing)
 copy_from_folder_on_reload | String | **Empty** | The location of a folder to copy files from into the folder defined by `config_location` whenever the configuration file is reloaded
 files_to_copy_from_folder | String List | **Empty** | The list of filenames to copy from the folder defined by `copy_from_folder_on_reload` (accepts `*` wildcards)
@@ -91,4 +92,3 @@ start_config_on_full | String | **Empty** | Start server with this config folder
 ## Upcoming Features
 - Support for running multiple server instances in one MultiAdmin instance
 - Printing speed configuration option
-- Exit timeout before killing the server process


### PR DESCRIPTION
### Config Changes
- Changed "multiadmin_debug_log" to default to true
- Added "use_new_input_system", if false, the original input system will be used

### Misc Changes
- Added tag logging to all debug messages
- Fixed "Server#ReloadConfig()" being called in init, this caused some features to run accidentally
- Moved new input system to a separate method so that it can be easily disabled
- Added startup printing for config file paths
- Added version to the MultiAdmin info command

### Bug Fixes
- Fixed console line clearing on Linux