### PR TITLE
MultiAdmin Version 3.2.4 Update

### DIFF
--- a/MultiAdmin/Config/MultiAdminConfig.cs
+++ b/MultiAdmin/Config/MultiAdminConfig.cs
@@ -138,6 +138,14 @@ namespace MultiAdmin.Config
 			new ConfigEntry<double>("server_stop_timeout", 10,
 				"Server Stop Timeout", "The time in seconds before MultiAdmin forces a server shutdown if it doesn't respond to the regular shutdown command");
 
+		public ConfigEntry<bool> ServerStartRetry { get; } =
+			new ConfigEntry<bool>("server_start_retry", true,
+				"Server Start Retry", "Whether to try to start the server again after crashing");
+
+		public ConfigEntry<int> ServerStartRetryDelay { get; } =
+			new ConfigEntry<int>("server_start_retry_delay", 10000,
+				"Server Start Retry Delay", "The time in milliseconds to wait before trying to start the server again after crashing");
+
 		public ConfigEntry<string> ServersFolder { get; } =
 			new ConfigEntry<string>("servers_folder", "servers",
 				"Servers Folder", "The location of the `servers` folder for MultiAdmin to load multiple server configurations from");

--- a/MultiAdmin/EventInterfaces.cs
+++ b/MultiAdmin/EventInterfaces.cs
@@ -1,43 +1,51 @@
 namespace MultiAdmin
 {
-	public interface IEventServerPreStart
+	public interface IMAEvent
+	{
+	}
+
+	public interface IEventServerPreStart: IMAEvent
 	{
 		void OnServerPreStart();
 	}
 
-	public interface IEventServerStart
+	public interface IEventServerStart: IMAEvent
 	{
 		void OnServerStart();
 	}
 
-	public interface IEventServerStop
+	public interface IEventServerStop: IMAEvent
 	{
 		void OnServerStop();
 	}
 
-	public interface IEventRoundEnd
+	public interface IEventRoundEnd: IMAEvent
 	{
 		void OnRoundEnd();
 	}
 
-	public interface IEventWaitingForPlayers
+	public interface IEventWaitingForPlayers: IMAEvent
 	{
 		void OnWaitingForPlayers();
 	}
 
-	public interface IEventRoundStart
+	public interface IEventRoundStart: IMAEvent
 	{
 		void OnRoundStart();
 	}
 
-	public interface IEventCrash
+	public interface IEventCrash: IMAEvent
 	{
 		void OnCrash();
 	}
 
-	public interface IEventTick
+	public interface IEventTick: IMAEvent
 	{
 		void OnTick();
+	}
+
+	public interface IServerMod: IMAEvent
+	{
 	}
 
 	public interface IEventServerFull : IServerMod
@@ -58,10 +66,6 @@ namespace MultiAdmin
 	public interface IEventAdminAction : IServerMod
 	{
 		void OnAdminAction(string message);
-	}
-
-	public interface IServerMod
-	{
 	}
 
 	public interface ICommand

--- a/MultiAdmin/Features/MultiAdminInfo.cs
+++ b/MultiAdmin/Features/MultiAdminInfo.cs
@@ -50,13 +50,12 @@ namespace MultiAdmin.Features
 
 		public void PrintInfo()
 		{
-			Server.Write($"MultiAdmin v{Program.MaVersion} (https://github.com/Grover-c13/MultiAdmin/)", ConsoleColor.DarkMagenta);
-			Server.Write("Released under MIT License Copyright © Grover 2019", ConsoleColor.DarkMagenta);
+			Server.Write($"{nameof(MultiAdmin)} v{Program.MaVersion} (https://github.com/Grover-c13/MultiAdmin/)\nReleased under MIT License Copyright © Grover 2019", ConsoleColor.DarkMagenta);
 		}
 
 		public override string GetFeatureDescription()
 		{
-			return "Prints MultiAdmin license and version information";
+			return $"Prints {nameof(MultiAdmin)} license and version information";
 		}
 
 		public override string GetFeatureName()

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -15,7 +15,7 @@ namespace MultiAdmin
 {
 	public static class Program
 	{
-		public const string MaVersion = "3.2.4.2";
+		public const string MaVersion = "3.2.4.3";
 		public const string RecommendedMonoVersion = "5.18";
 
 		private static readonly List<Server> InstantiatedServers = new List<Server>();

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -21,7 +21,7 @@ namespace MultiAdmin
 		private static readonly List<Server> InstantiatedServers = new List<Server>();
 
 		private static readonly string MaDebugLogDir = Utils.GetFullPathSafe("logs");
-		private static readonly string MaDebugLogFile = !string.IsNullOrEmpty(MaDebugLogDir) ? Utils.GetFullPathSafe($"{MaDebugLogDir}{Path.DirectorySeparatorChar}{Utils.DateTime}_MA_{MaVersion}_debug_log.txt") : null;
+		private static readonly string MaDebugLogFile = !string.IsNullOrEmpty(MaDebugLogDir) ? Utils.GetFullPathSafe(Path.Combine(MaDebugLogDir, $"{Utils.DateTime}_MA_{MaVersion}_debug_log.txt")) : null;
 
 		private static uint? portArg;
 

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -15,8 +15,8 @@ namespace MultiAdmin
 {
 	public static class Program
 	{
-		public const string MaVersion = "3.2.4.1";
-		public const string RecommendedMonoVersion = "5.18.0";
+		public const string MaVersion = "3.2.4.2";
+		public const string RecommendedMonoVersion = "5.18";
 
 		private static readonly List<Server> InstantiatedServers = new List<Server>();
 
@@ -178,7 +178,8 @@ namespace MultiAdmin
 
 			Headless = GetFlagFromArgs("headless", "h");
 
-			CheckMonoVersion();
+			if (!Headless)
+				CheckMonoVersion();
 
 			string serverIdArg = GetParamFromArgs("server-id", "id");
 			string configArg = GetParamFromArgs("config", "c");
@@ -372,11 +373,11 @@ namespace MultiAdmin
 			return serverProcess;
 		}
 
-		private static bool IsVersionFormat(string input)
+		private static bool IsVersionFormat(string input, char separator = '.')
 		{
 			foreach (char character in input)
 			{
-				if (!char.IsNumber(character) && character != '.')
+				if (!char.IsNumber(character) && character != separator)
 					return false;
 			}
 
@@ -388,17 +389,17 @@ namespace MultiAdmin
 			try
 			{
 				string monoVersionRaw = Type.GetType("Mono.Runtime")?.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static)?.Invoke(null, null)?.ToString();
-				string monoVersion = monoVersionRaw?.Split(' ').FirstOrDefault(IsVersionFormat);
+				string monoVersion = monoVersionRaw?.Split(' ').FirstOrDefault(version => IsVersionFormat(version));
 
 				if (string.IsNullOrEmpty(monoVersion))
 					return;
 
 				int versionDifference = Utils.CompareVersionStrings(monoVersion, RecommendedMonoVersion);
 
-				if (versionDifference >= 0 && (versionDifference != 0 || monoVersion.Length >= RecommendedMonoVersion.Length))
+				if (versionDifference >= 0)
 					return;
 
-				Write($"Warning: Your Mono version ({monoVersion}) is below the recommended version ({RecommendedMonoVersion})", ConsoleColor.Red);
+				Write($"Warning: Your Mono version ({monoVersion}) is below the minimum recommended version ({RecommendedMonoVersion})", ConsoleColor.Red);
 				Write("Please update your Mono installation: https://www.mono-project.com/download/stable/", ConsoleColor.Red);
 			}
 			catch (Exception e)

--- a/MultiAdmin/Program.cs
+++ b/MultiAdmin/Program.cs
@@ -15,7 +15,7 @@ namespace MultiAdmin
 {
 	public static class Program
 	{
-		public const string MaVersion = "3.2.3.1";
+		public const string MaVersion = "3.2.4.1";
 		public const string RecommendedMonoVersion = "5.18.0";
 
 		private static readonly List<Server> InstantiatedServers = new List<Server>();

--- a/MultiAdmin/Server.cs
+++ b/MultiAdmin/Server.cs
@@ -768,7 +768,7 @@ namespace MultiAdmin
 			}
 			catch (Exception e)
 			{
-				Write(new ColoredMessage[] {new ColoredMessage("Error while copying files and folders:", ConsoleColor.Red), new ColoredMessage(e.ToString(), ConsoleColor.Red)});
+				Write($"Error while copying files and folders:\n{e}", ConsoleColor.Red);
 			}
 
 			return false;

--- a/MultiAdmin/Utility/Utils.cs
+++ b/MultiAdmin/Utility/Utils.cs
@@ -90,10 +90,15 @@ namespace MultiAdmin.Utility
 				if (matchIndex < 0 || matchIndex >= input.Length)
 					return false;
 
-				Program.LogDebug(nameof(StringMatches), $"Matching \"{wildCardSection}\" with \"{input.Substring(matchIndex)}\"...");;
+				Program.LogDebug(nameof(StringMatches), $"Matching \"{wildCardSection}\" with \"{input.Substring(matchIndex)}\"...");
 
 				if (matchIndex <= 0 && pattern[0] != WildCard)
 				{
+					// If the rest of the input string isn't at least as long as the section to match
+					if (input.Length - matchIndex < wildCardSection.Length)
+						return false;
+
+					// If the input doesn't match this section of the pattern
 					if (!input.Equals(wildCardSection, matchIndex, wildCardSection.Length))
 						return false;
 

--- a/MultiAdmin/Utility/Utils.cs
+++ b/MultiAdmin/Utility/Utils.cs
@@ -56,7 +56,7 @@ namespace MultiAdmin.Utility
 
 		private const char WildCard = '*';
 
-		public static bool StringMatches(string input, string pattern)
+		public static bool StringMatches(string input, string pattern, char wildCard = WildCard)
 		{
 			if (input == null && pattern == null)
 				return true;
@@ -64,7 +64,7 @@ namespace MultiAdmin.Utility
 			if (pattern == null)
 				return false;
 
-			if (!pattern.IsEmpty() && pattern == new string(WildCard, pattern.Length))
+			if (!pattern.IsEmpty() && pattern == new string(wildCard, pattern.Length))
 				return true;
 
 			if (input == null)
@@ -76,7 +76,7 @@ namespace MultiAdmin.Utility
 			if (input.IsEmpty() || pattern.IsEmpty())
 				return false;
 
-			string[] wildCardSections = pattern.Split(WildCard);
+			string[] wildCardSections = pattern.Split(wildCard);
 
 			int matchIndex = 0;
 			foreach (string wildCardSection in wildCardSections)
@@ -92,7 +92,7 @@ namespace MultiAdmin.Utility
 
 				Program.LogDebug(nameof(StringMatches), $"Matching \"{wildCardSection}\" with \"{input.Substring(matchIndex)}\"...");
 
-				if (matchIndex <= 0 && pattern[0] != WildCard)
+				if (matchIndex <= 0 && pattern[0] != wildCard)
 				{
 					// If the rest of the input string isn't at least as long as the section to match
 					if (input.Length - matchIndex < wildCardSection.Length)
@@ -174,31 +174,67 @@ namespace MultiAdmin.Utility
 			CopyAll(new DirectoryInfo(source), new DirectoryInfo(target), fileWhitelist, fileBlacklist);
 		}
 
-		public static int CompareVersionStrings(string firstVersion, string secondVersion)
+		public static int[] StringArrayToIntArray(string[] stringArray)
+		{
+			lock (stringArray)
+			{
+				int[] intArray = new int[stringArray.Length];
+
+				for (int i = 0; i < stringArray.Length; i++)
+				{
+					if (!int.TryParse(stringArray[i], out int intValue))
+						continue;
+
+					intArray[i] = intValue;
+				}
+
+				return intArray;
+			}
+		}
+
+		/// <summary>
+		/// Compares <paramref name="firstVersion"/> to <paramref name="secondVersion"/>
+		/// </summary>
+		/// <param name="firstVersion">The version string to compare</param>
+		/// <param name="secondVersion">The version string to compare to</param>
+		/// <param name="separator">The separator character between version numbers</param>
+		/// <returns>
+		/// Returns 1 if <paramref name="firstVersion"/> is greater than (or longer if equal) <paramref name="secondVersion"/>,
+		/// 0 if <paramref name="firstVersion"/> is exactly equal to <paramref name="secondVersion"/>,
+		/// and -1 if <paramref name="firstVersion"/> is less than (or shorter if equal) <paramref name="secondVersion"/>
+		/// </returns>
+		public static int CompareVersionStrings(string firstVersion, string secondVersion, char separator = '.')
 		{
 			if (firstVersion == null || secondVersion == null)
 				return -1;
 
-			string[] firstVersionNums = firstVersion.Split('.');
-			string[] secondVersionNums = secondVersion.Split('.');
+			int[] firstVersionNums = StringArrayToIntArray(firstVersion.Split(separator));
+			int[] secondVersionNums = StringArrayToIntArray(secondVersion.Split(separator));
 			int minVersionLength = Math.Min(firstVersionNums.Length, secondVersionNums.Length);
 
+			// Compare version numbers
 			for (int i = 0; i < minVersionLength; i++)
 			{
-				if (!int.TryParse(firstVersionNums[i], out int first) || !int.TryParse(secondVersionNums[i], out int second))
-					continue;
-
-				if (first > second)
+				if (firstVersionNums[i] > secondVersionNums[i])
 				{
 					return 1;
 				}
 
-				if (first < second)
+				if (firstVersionNums[i] < secondVersionNums[i])
 				{
 					return -1;
 				}
 			}
 
+			// If all the numbers are the same
+
+			// Compare version lengths
+			if (firstVersionNums.Length > secondVersionNums.Length)
+				return 1;
+			if (firstVersionNums.Length < secondVersionNums.Length)
+				return -1;
+
+			// If the versions are perfectly identical, return 0
 			return 0;
 		}
 	}

--- a/MultiAdminTests/Utility/UtilsTests.cs
+++ b/MultiAdminTests/Utility/UtilsTests.cs
@@ -103,18 +103,18 @@ namespace MultiAdminTests.Utility
 				new CompareVersionTemplate("2.0.0.0", "1.0.0.0", 1),
 
 				new CompareVersionTemplate("1.0", "2.0.0.0", -1),
-				new CompareVersionTemplate("1.0", "1.0.0.0", 0),
+				new CompareVersionTemplate("1.0", "1.0.0.0", -1), // The first version is shorter, so it's lower
 				new CompareVersionTemplate("2.0", "1.0.0.0", 1),
 
 				new CompareVersionTemplate("1.0.0.0", "2.0", -1),
-				new CompareVersionTemplate("1.0.0.0", "1.0", 0),
+				new CompareVersionTemplate("1.0.0.0", "1.0", 1), // The first version is longer, so it's higher
 				new CompareVersionTemplate("2.0.0.0", "1.0", 1),
 
 				new CompareVersionTemplate("6.0.0.313", "5.18.0", 1),
 				new CompareVersionTemplate("5.18.0", "6.0.0.313", -1),
 
 				new CompareVersionTemplate("5.18.0", "5.18.0", 0),
-				new CompareVersionTemplate("5.18", "5.18.0", 0)
+				new CompareVersionTemplate("5.18", "5.18.0", -1) // The first version is shorter, so it's lower
 			};
 
 			for (int i = 0; i < versionTests.Length; i++)

--- a/MultiAdminTests/Utility/UtilsTests.cs
+++ b/MultiAdminTests/Utility/UtilsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MultiAdmin.Utility;
 
@@ -70,15 +71,25 @@ namespace MultiAdminTests.Utility
 				new StringMatchingTemplate("test", "t**st", true),
 				new StringMatchingTemplate("test", "s*", false),
 				new StringMatchingTemplate("longstringtestmessage", "l*s*t*e*g*", true),
+				new StringMatchingTemplate("AdminToolbox", "config_remoteadmin.txt", false),
+				new StringMatchingTemplate("config_remoteadmin.txt", "config_remoteadmin.txt", true),
+				new StringMatchingTemplate("sizetest", "sizetest1", false)
 			};
 
 			for (int i = 0; i < matchTests.Length; i++)
 			{
-				StringMatchingTemplate test = matchTests[i];
+				try
+				{
+					StringMatchingTemplate test = matchTests[i];
 
-				bool result = Utils.StringMatches(test.input, test.pattern);
+					bool result = Utils.StringMatches(test.input, test.pattern);
 
-				Assert.IsTrue(test.expectedResult == result, $"Failed on test index {i}: Expected \"{test.expectedResult}\", got \"{result}\"");
+					Assert.IsTrue(test.expectedResult == result, $"Failed on test index {i}: Expected \"{test.expectedResult}\", got \"{result}\"");
+				}
+				catch (Exception e)
+				{
+					Assert.Fail($"Failed on test index {i}: {e}");
+				}
 			}
 		}
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ safe_shutdown_check_delay | Integer | 100 | The time in milliseconds between che
 safe_shutdown_timeout | Integer | 10000 | The time in milliseconds before MultiAdmin gives up on safely shutting down a server
 server_restart_timeout | Double | 10 | The time in seconds before MultiAdmin forces a server restart if it doesn't respond to the regular restart command
 server_stop_timeout | Double | 10 | The time in seconds before MultiAdmin forces a server shutdown if it doesn't respond to the regular shutdown command
+server_start_retry | Boolean | True | Whether to try to start the server again after crashing
+server_start_retry_delay | Integer | 10000 | The time in milliseconds to wait before trying to start the server again after crashing
 servers_folder | String | servers | The location of the `servers` folder for MultiAdmin to load multiple server configurations from
 set_title_bar | Boolean | True | Whether to set the console window's titlebar, if false, this feature won't be used
 shutdown_when_empty_for | Integer | -1 | Shutdown the server once a round hasn't started in a number of seconds


### PR DESCRIPTION
## Config Additions
- Add startup fail configs
  - Add `server_start_retry`
  - Add `server_start_retry_delay`

## Bug Fixes
- Add missing check to StringMatches

## Misc Changes
- Add more unit testing for StringMatches
- Add new event calling system, this should reduce duplicated code
- Update Mono version checker to check length better
- Update a couple of info messages
- Change the server start-up crash message
- Check if a command is already registered before registering
- Safer and more optimized OutputHandler index checks
- Modify CompareVersion to check version length as well as the numbers
- Change all usages of `Path.DirectorySeparatorChar` for combining paths to `Path.Combine()`