### PR TITLE
Modify the current user count calculation in the TitleBar Feature

### DIFF
--- a/MultiAdmin/Features/TitleBar.cs
+++ b/MultiAdmin/Features/TitleBar.cs
@@ -57,7 +57,7 @@ namespace MultiAdmin.Features
 
 		public override void Init()
 		{
-			playerCount = -1; // -1 for the "server" player, once the server starts this will increase to 0.
+			playerCount = 0;
 			UpdateTitlebar();
 		}
 


### PR DESCRIPTION
In **MP2**, the `server` player was removed.
So i changed the initial `playerCount` value from `-1` to `0`.


**Note**: If this PR becomes Merge, the **current number of users** in the **MP2 past version** may appear to be 1 less.